### PR TITLE
docs: removed the squad name from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Core APIs Go Service Template
+# MadeiraMadeira Go Service Template
 
 MadeiraMadeira boilerplate project to build scalable, testable and high performance Go microservices.
 
@@ -95,5 +95,3 @@ $ docker build \
     -t go-service-template-production:latest \
     -f docker/Dockerfile .
 ```
----
-Squad Core APIs • [MadeiraMadeira](https://www.madeiramadeira.com.br)


### PR DESCRIPTION
We want to encourage other squads to contribute with our templates. It is good that everyone sees these templates as a company thing and not attached to one squad or another. It would be nice to remove the [COREAPI-XXXX] from the PR template as well. 

Remember guys, these are only suggestions. I want to encourage people to collaborate more.

## Proposed changes

Change the readme text to be more neutral

## Checklist

- [ ] Have you written tests for your changes?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Have you lint your code locally prior to submission?