### PR TITLE
Add catalog-info.yaml for Portal DX integration.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: template-service-go
+  annotations:
+    github.com/project-slug: madeiramadeirabr/template-service-go
+  tags:
+    - go
+spec:
+  type: service
+  lifecycle: production
+  owner: team-platform-engineering-admin
+  


### PR DESCRIPTION
Esta solicitação pull adiciona um **arquivo de metadados de entidade Backstage** a este repositório para que o componente possa ser adicionado ao catálogo de software da MadeiraMadeira no Portal DX.

Depois que essa solicitação pull for mesclada, o componente ficará disponível.

Sinta-se à vontade para fazer alterações no arquivo. Para mais informações, leia a documentação com as orientações específicas em [Arquivo de Configuração](https://madeiramadeira.atlassian.net/wiki/spaces/DX/pages/2744844533/Arquivo+de+Configura+o) no Confluence do DX Team.